### PR TITLE
リマインド頻度設定とエンタメ登録時のリマインド関係のテーブルへ保存

### DIFF
--- a/src/app/reminder/page.js
+++ b/src/app/reminder/page.js
@@ -1,0 +1,151 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import api from '@/lib/axios' // axios インスタンスを利用
+
+export default function ReminderPage() {
+    const [loading, setLoading] = useState(true)
+    const [remindMode, setRemindMode] = useState(0) // 0=default, 1=custom, 2=off
+    const [intervals, setIntervals] = useState({
+        0: null, // 本
+        1: null, // マンガ
+        2: null, // 映画
+        3: null, // 音楽
+        4: null, // Podcast
+        5: null, // TV
+    })
+
+    const options = [
+        { value: null, label: '登録なし' },
+        { value: 5, label: '5日' },
+        { value: 7, label: '1週間' },
+        { value: 14, label: '2週間' },
+        { value: 21, label: '3週間' },
+        { value: 30, label: '1か月' },
+        { value: 60, label: '2か月' },
+    ]
+
+    // 初期データをAPIから取得
+    useEffect(() => {
+        async function fetchData() {
+            try {
+                const res = await api.get('/api/remind-setting')
+                setRemindMode(res.data.mode)
+
+                const resIntervals = await api.get('/api/intervals')
+                const mapped = {}
+                resIntervals.data.forEach(i => {
+                    mapped[i.kind] = i.interval_days
+                })
+                setIntervals(mapped)
+
+                setLoading(false)
+            } catch (error) {
+                console.error('Fetch error:', error)
+                setLoading(false)
+            }
+        }
+        fetchData()
+    }, [])
+
+    const handleSubmit = async () => {
+        try {
+            // モード更新
+            await api.put('/api/remind-setting', { mode: remindMode })
+
+            // カスタム時は intervals も更新
+            if (remindMode === 1) {
+                await api.put('/api/intervals', { intervals })
+            }
+
+            alert('リマインド設定を更新しました')
+        } catch (error) {
+            console.error('Update error:', error)
+            alert('更新に失敗しました')
+        }
+    }
+
+    if (loading) return <p>Loading...</p>
+
+    return (
+        <div style={{ padding: '1rem' }}>
+            <h1>リマインド設定</h1>
+
+            <div>
+                <label>
+                    <input
+                        type="radio"
+                        name="remindMode"
+                        value={0}
+                        checked={remindMode === 0}
+                        onChange={() => setRemindMode(0)}
+                    />
+                    デフォルト（記録から2週間ごと）
+                </label>
+            </div>
+
+            <div>
+                <label>
+                    <input
+                        type="radio"
+                        name="remindMode"
+                        value={1}
+                        checked={remindMode === 1}
+                        onChange={() => setRemindMode(1)}
+                    />
+                    自分で設定する（各ジャンル）
+                </label>
+            </div>
+
+            {remindMode === 1 && (
+                <div style={{ marginLeft: '1rem' }}>
+                    {Object.entries({
+                        0: '本',
+                        1: 'マンガ',
+                        2: '映画',
+                        3: '音楽',
+                        4: 'Podcast',
+                        5: 'TV・配信サービス',
+                    }).map(([kind, label]) => (
+                        <div key={kind}>
+                            <label>{label}</label>
+                            <select
+                                value={intervals[kind] ?? ''}
+                                onChange={e =>
+                                    setIntervals({
+                                        ...intervals,
+                                        [kind]: e.target.value || null,
+                                    })
+                                }>
+                                {options.map(o => (
+                                    <option
+                                        key={o.value ?? 'null'}
+                                        value={o.value ?? ''}>
+                                        {o.label}
+                                    </option>
+                                ))}
+                            </select>
+                        </div>
+                    ))}
+                </div>
+            )}
+
+            <div>
+                <label>
+                    <input
+                        type="radio"
+                        name="remindMode"
+                        value={2}
+                        checked={remindMode === 2}
+                        onChange={() => setRemindMode(2)}
+                    />
+                    リマインドをしない
+                </label>
+            </div>
+
+            <button onClick={handleSubmit} style={{ marginTop: '1rem' }}>
+                更新
+            </button>
+        </div>
+    )
+}

--- a/src/app/titles/[id]/edit/page.js
+++ b/src/app/titles/[id]/edit/page.js
@@ -18,7 +18,8 @@ export default function EditTitlePage() {
     const [errors, setErrors] = useState({})
 
     useEffect(() => {
-        axios.get(`/api/titles/${id}/edit-data`)
+        axios
+            .get(`/api/titles/${id}/edit-data`)
             .then(res => setForm(prev => ({ ...prev, ...res.data })))
             .catch(err => console.error(err))
     }, [id])
@@ -46,7 +47,8 @@ export default function EditTitlePage() {
 
     // 👇 削除処理
     const handleDelete = async () => {
-        if (!confirm('このタイトルと感想をすべて削除します。よろしいですか？')) return
+        if (!confirm('このタイトルと感想をすべて削除します。よろしいですか？'))
+            return
         try {
             await axios.delete(`/api/titles/${id}`)
             alert('タイトルを削除しました')
@@ -63,14 +65,22 @@ export default function EditTitlePage() {
             <form onSubmit={handleSubmit} className="space-y-4">
                 <div>
                     <label>ジャンル *</label>
-                    <input
-                        type="text"
+                    <select
                         name="genre"
                         value={form.genre}
                         onChange={handleChange}
                         required
-                        className="border p-2 w-full"
-                    />
+                        className="border p-2 w-full">
+                        <option value="本">本</option>
+                        <option value="マンガ">マンガ</option>
+                        <option value="映画">映画</option>
+                        <option value="音楽">音楽</option>
+                        <option value="ポッドキャスト">ポッドキャスト</option>
+                        <option value="TV・動画配信サービス">
+                            TV・動画配信サービス
+                        </option>
+                        <option value="その他">その他</option>
+                    </select>
                 </div>
                 <div>
                     <label>タイトル *</label>
@@ -106,17 +116,20 @@ export default function EditTitlePage() {
                 </div>
 
                 <div className="flex gap-4">
-                    <button type="submit" className="bg-blue-600 text-white px-4 py-2 rounded">
+                    <button
+                        type="submit"
+                        className="bg-blue-600 text-white px-4 py-2 rounded">
                         更新する
                     </button>
                     <button
                         type="button"
                         onClick={handleDelete}
-                        className="bg-red-600 text-white px-4 py-2 rounded"
-                    >
+                        className="bg-red-600 text-white px-4 py-2 rounded">
                         削除する
                     </button>
-                    <Link href={`/titles/${id}`} className="text-blue-600 underline">
+                    <Link
+                        href={`/titles/${id}`}
+                        className="text-blue-600 underline">
                         詳細に戻る
                     </Link>
                 </div>


### PR DESCRIPTION
- 登録ページの作成
- ジャンル周りの登録や修正の調整

※登録時は、ジャンルを名前で登録していたが、リマインド用のジャンルはkindとして数字で登録しようとしてた
時間があれば、すべて数字でテーブルには保存できるようにしたい！

closes #14 
closes #22 
